### PR TITLE
Fix the parser and remove monadic let.

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -499,8 +499,6 @@ rule token = parse
             { INFIXOP3(Lexing.lexeme lexbuf) }
   | '#' (symbolchar | '#') +
             { SHARPOP(Lexing.lexeme lexbuf) }
-  | "let" symbolchar*                            (* NNN *)
-            { LETOP(Lexing.lexeme lexbuf) }      (* NNN *)
   | eof { EOF }
   | _
       { raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -385,13 +385,13 @@ let let_operator op bindings cont =
     match bindings.lbs_bindings with
     | []   -> assert false
     | [x]  -> (x.lb_pattern, x.lb_expression)
-    | l    -> 
-        let pats, exprs = 
+    | l    ->
+        let pats, exprs =
           List.fold_right
             (fun {lb_pattern=p;lb_expression=e} (ps,es) -> (p::ps,e::es)) l ([],[]) in
         ghpat (Ppat_tuple pats), ghexp (Pexp_tuple exprs)
     in
-      mkexp(Pexp_apply(op, [(Nolabel, expr); 
+      mkexp(Pexp_apply(op, [(Nolabel, expr);
                             (Nolabel, ghexp(Pexp_fun(Nolabel, None, pat, cont)))]))
 %}
 
@@ -1336,10 +1336,10 @@ simple_expr:
   | LPAREN seq_expr error
       { unclosed "(" 1 ")" 3 }
   | DOTLESS expr GREATERDOT                 /* NNN */
-      { wrap_exp_attrs $2 
+      { wrap_exp_attrs $2
            (None,[ghloc "metaocaml.bracket",PStr []]) }            /* NNN */
   | DOTTILDE simple_expr %prec prec_escape  /* NNN */
-      { wrap_exp_attrs $2 
+      { wrap_exp_attrs $2
            (None,[ghloc "metaocaml.escape",PStr []]) }             /* NNN */
   | BEGIN ext_attributes seq_expr END
       { wrap_exp_attrs (reloc_exp $3) $2 (* check location *) }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -591,6 +591,7 @@ The precedences must be listed from low to high.
           LBRACE LBRACELESS LBRACKET LBRACKETBAR LIDENT LPAREN
           NEW NATIVEINT PREFIXOP STRING TRUE UIDENT
           LBRACKETPERCENT LBRACKETPERCENTPERCENT
+          DOTLESS DOTTILDE /* NNN */
 
 
 /* Entry points */


### PR DESCRIPTION
Monadic let was completely broken (the syntax was `let! let x = .. in ...`, yes, with 2 "let") so I just removed it instead of trying to fix it.

If you really want it, I can add it again, I know how to do it, but it didn't seem worth the trouble.

I fixed some shift/reduce conflicts along the way.
